### PR TITLE
Device enumeration causes a cpu spike and no output for 20 seconds

### DIFF
--- a/streamdeck-audiometer/Actions/AudioMeterAction.cs
+++ b/streamdeck-audiometer/Actions/AudioMeterAction.cs
@@ -254,14 +254,21 @@ namespace AudioMeter.Actions
         {
             if (mmDevice == null)
             {
-                if (!(sender is Timer timer)) return;
-                var interval = timer.Interval;
+                if (sender is Timer timer)
+                {
+                    var interval = timer.Interval;
 
-                timer.Interval = 30000;
+                    timer.Interval = 30000;
 
-                SetMMDeviceFromDeviceName(settings.AudioDevice);
+                    SetMMDeviceFromDeviceName(settings.AudioDevice);
 
-                timer.Interval = Math.Min(200, interval);
+                    timer.Interval = Math.Min(200, interval);
+
+                }
+                else // just a safe guard in case something else is calling us that isn't a timer we can control
+                {
+                    SetMMDeviceFromDeviceName(settings.AudioDevice);
+                }
             }
 
             if (mmDevice != null)

--- a/streamdeck-audiometer/Actions/AudioMeterAction.cs
+++ b/streamdeck-audiometer/Actions/AudioMeterAction.cs
@@ -12,6 +12,7 @@ using System.IO;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using System.Timers;
 
 namespace AudioMeter.Actions
 {
@@ -253,7 +254,14 @@ namespace AudioMeter.Actions
         {
             if (mmDevice == null)
             {
+                if (!(sender is Timer timer)) return;
+                var interval = timer.Interval;
+
+                timer.Interval = 30000;
+
                 SetMMDeviceFromDeviceName(settings.AudioDevice);
+
+                timer.Interval = Math.Min(200, interval);
             }
 
             if (mmDevice != null)
@@ -283,7 +291,7 @@ namespace AudioMeter.Actions
             }
 
             MMDeviceEnumerator enumerator = new MMDeviceEnumerator();
-            mmDevice = enumerator.EnumerateAudioEndPoints(DataFlow.All, DeviceState.Active).ToList().Where(d => d.FriendlyName == deviceName).FirstOrDefault();
+            mmDevice = enumerator.EnumerateAudioEndPoints(DataFlow.All, DeviceState.Active).ToList().FirstOrDefault(d => d.FriendlyName == deviceName);
         }
 
         private async Task DisplayMeter(int level)

--- a/streamdeck-audiometer/App.config
+++ b/streamdeck-audiometer/App.config
@@ -7,7 +7,7 @@
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
         <assemblyIdentity name="CommandLine" publicKeyToken="5a870481e358d379" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-2.6.0.0" newVersion="2.6.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-2.9.1.0" newVersion="2.9.1.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
@@ -19,7 +19,7 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="System.Drawing.Common" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-4.0.0.2" newVersion="4.0.0.2" />
+        <bindingRedirect oldVersion="0.0.0.0-6.0.0.0" newVersion="6.0.0.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/streamdeck-audiometer/AudioMeter.csproj
+++ b/streamdeck-audiometer/AudioMeter.csproj
@@ -33,60 +33,48 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="CommandLine, Version=2.8.0.0, Culture=neutral, PublicKeyToken=5a870481e358d379, processorArchitecture=MSIL">
-      <HintPath>..\..\..\DotNet\StreamDeck\packages\CommandLineParser.2.8.0\lib\net461\CommandLine.dll</HintPath>
+    <Reference Include="CommandLine, Version=2.9.1.0, Culture=neutral, PublicKeyToken=5a870481e358d379, processorArchitecture=MSIL">
+      <HintPath>..\packages\CommandLineParser.2.9.1\lib\net461\CommandLine.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Win32.Registry, Version=5.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\..\..\DotNet\StreamDeck\packages\Microsoft.Win32.Registry.5.0.0\lib\net461\Microsoft.Win32.Registry.dll</HintPath>
+    <Reference Include="NAudio, Version=2.1.0.0, Culture=neutral, PublicKeyToken=e279aa5131008a41, processorArchitecture=MSIL">
+      <HintPath>..\packages\NAudio.2.1.0\lib\net472\NAudio.dll</HintPath>
     </Reference>
-    <Reference Include="NAudio, Version=2.0.0.0, Culture=neutral, PublicKeyToken=e279aa5131008a41, processorArchitecture=MSIL">
-      <HintPath>..\..\..\DotNet\StreamDeck\packages\NAudio.2.0.0\lib\netstandard2.0\NAudio.dll</HintPath>
+    <Reference Include="NAudio.Asio, Version=2.1.0.0, Culture=neutral, PublicKeyToken=e279aa5131008a41, processorArchitecture=MSIL">
+      <HintPath>..\packages\NAudio.Asio.2.1.0\lib\netstandard2.0\NAudio.Asio.dll</HintPath>
     </Reference>
-    <Reference Include="NAudio.Asio, Version=2.0.0.0, Culture=neutral, PublicKeyToken=e279aa5131008a41, processorArchitecture=MSIL">
-      <HintPath>..\..\..\DotNet\StreamDeck\packages\NAudio.Asio.2.0.0\lib\netstandard2.0\NAudio.Asio.dll</HintPath>
+    <Reference Include="NAudio.Core, Version=2.1.0.0, Culture=neutral, PublicKeyToken=e279aa5131008a41, processorArchitecture=MSIL">
+      <HintPath>..\packages\NAudio.Core.2.1.0\lib\netstandard2.0\NAudio.Core.dll</HintPath>
     </Reference>
-    <Reference Include="NAudio.Core, Version=2.0.0.0, Culture=neutral, PublicKeyToken=e279aa5131008a41, processorArchitecture=MSIL">
-      <HintPath>..\..\..\DotNet\StreamDeck\packages\NAudio.Core.2.0.0\lib\netstandard2.0\NAudio.Core.dll</HintPath>
+    <Reference Include="NAudio.Midi, Version=2.1.0.0, Culture=neutral, PublicKeyToken=e279aa5131008a41, processorArchitecture=MSIL">
+      <HintPath>..\packages\NAudio.Midi.2.1.0\lib\netstandard2.0\NAudio.Midi.dll</HintPath>
     </Reference>
-    <Reference Include="NAudio.Midi, Version=2.0.0.0, Culture=neutral, PublicKeyToken=e279aa5131008a41, processorArchitecture=MSIL">
-      <HintPath>..\..\..\DotNet\StreamDeck\packages\NAudio.Midi.2.0.0\lib\netstandard2.0\NAudio.Midi.dll</HintPath>
+    <Reference Include="NAudio.Wasapi, Version=2.1.0.0, Culture=neutral, PublicKeyToken=e279aa5131008a41, processorArchitecture=MSIL">
+      <HintPath>..\packages\NAudio.Wasapi.2.1.0\lib\netstandard2.0\NAudio.Wasapi.dll</HintPath>
     </Reference>
-    <Reference Include="NAudio.Wasapi, Version=2.0.0.0, Culture=neutral, PublicKeyToken=e279aa5131008a41, processorArchitecture=MSIL">
-      <HintPath>..\..\..\DotNet\StreamDeck\packages\NAudio.Wasapi.2.0.0\lib\netstandard2.0\NAudio.Wasapi.dll</HintPath>
+    <Reference Include="NAudio.WinForms, Version=2.1.0.0, Culture=neutral, PublicKeyToken=e279aa5131008a41, processorArchitecture=MSIL">
+      <HintPath>..\packages\NAudio.WinForms.2.1.0\lib\net472\NAudio.WinForms.dll</HintPath>
     </Reference>
-    <Reference Include="NAudio.WinForms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=e279aa5131008a41, processorArchitecture=MSIL">
-      <HintPath>..\..\..\DotNet\StreamDeck\packages\NAudio.WinForms.2.0.0\lib\net472\NAudio.WinForms.dll</HintPath>
-    </Reference>
-    <Reference Include="NAudio.WinMM, Version=2.0.0.0, Culture=neutral, PublicKeyToken=e279aa5131008a41, processorArchitecture=MSIL">
-      <HintPath>..\..\..\DotNet\StreamDeck\packages\NAudio.WinMM.2.0.0\lib\netstandard2.0\NAudio.WinMM.dll</HintPath>
+    <Reference Include="NAudio.WinMM, Version=2.1.0.0, Culture=neutral, PublicKeyToken=e279aa5131008a41, processorArchitecture=MSIL">
+      <HintPath>..\packages\NAudio.WinMM.2.1.0\lib\netstandard2.0\NAudio.WinMM.dll</HintPath>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=13.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\..\..\DotNet\StreamDeck\packages\Newtonsoft.Json.13.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
-    <Reference Include="NLog, Version=4.0.0.0, Culture=neutral, PublicKeyToken=5120e14c03d0593c, processorArchitecture=MSIL">
-      <HintPath>..\..\..\DotNet\StreamDeck\packages\NLog.4.7.10\lib\net45\NLog.dll</HintPath>
-    </Reference>
     <Reference Include="streamdeck-client-csharp, Version=4.3.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\..\DotNet\StreamDeck\packages\streamdeck-client-csharp.4.3.0\lib\netstandard2.0\streamdeck-client-csharp.dll</HintPath>
+      <HintPath>..\packages\streamdeck-client-csharp.4.3.0\lib\netstandard2.0\streamdeck-client-csharp.dll</HintPath>
     </Reference>
     <Reference Include="StreamDeckTools, Version=3.2.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\..\DotNet\StreamDeck\packages\StreamDeck-Tools.3.2.0\lib\net472\StreamDeckTools.dll</HintPath>
+      <HintPath>..\packages\StreamDeck-Tools.3.2.0\lib\net472\StreamDeckTools.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Configuration" />
     <Reference Include="System.Core" />
     <Reference Include="System.Drawing" />
-    <Reference Include="System.Drawing.Common, Version=4.0.0.2, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\..\..\DotNet\StreamDeck\packages\System.Drawing.Common.5.0.2\lib\net461\System.Drawing.Common.dll</HintPath>
+    <Reference Include="System.Drawing.Common, Version=6.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Drawing.Common.6.0.0\lib\net461\System.Drawing.Common.dll</HintPath>
     </Reference>
     <Reference Include="System.IO.Compression" />
     <Reference Include="System.Runtime.Serialization" />
-    <Reference Include="System.Security.AccessControl, Version=5.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\..\..\DotNet\StreamDeck\packages\System.Security.AccessControl.5.0.0\lib\net461\System.Security.AccessControl.dll</HintPath>
-    </Reference>
-    <Reference Include="System.Security.Principal.Windows, Version=5.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\..\..\DotNet\StreamDeck\packages\System.Security.Principal.Windows.5.0.0\lib\net461\System.Security.Principal.Windows.dll</HintPath>
-    </Reference>
     <Reference Include="System.ServiceModel" />
     <Reference Include="System.Transactions" />
     <Reference Include="System.Windows.Forms" />

--- a/streamdeck-audiometer/AudioMeter.csproj
+++ b/streamdeck-audiometer/AudioMeter.csproj
@@ -60,6 +60,9 @@
     <Reference Include="Newtonsoft.Json, Version=13.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\..\..\DotNet\StreamDeck\packages\Newtonsoft.Json.13.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
+    <Reference Include="NLog, Version=4.0.0.0, Culture=neutral, PublicKeyToken=5120e14c03d0593c, processorArchitecture=MSIL">
+      <HintPath>..\packages\NLog.4.7.6\lib\net45\NLog.dll</HintPath>
+    </Reference>
     <Reference Include="streamdeck-client-csharp, Version=4.3.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\streamdeck-client-csharp.4.3.0\lib\netstandard2.0\streamdeck-client-csharp.dll</HintPath>
     </Reference>

--- a/streamdeck-audiometer/packages.config
+++ b/streamdeck-audiometer/packages.config
@@ -9,7 +9,7 @@
   <package id="NAudio.WinForms" version="2.1.0" targetFramework="net472" />
   <package id="NAudio.WinMM" version="2.1.0" targetFramework="net472" />
   <package id="Newtonsoft.Json" version="13.0.1" targetFramework="net472" />
-  <package id="NLog" version="5.0.1" targetFramework="net472" />
+  <package id="NLog" version="4.7.6" targetFramework="net472" />
   <package id="streamdeck-client-csharp" version="4.3.0" targetFramework="net472" />
   <package id="StreamDeck-Tools" version="3.2.0" targetFramework="net472" />
   <package id="System.Drawing.Common" version="6.0.0" targetFramework="net472" />

--- a/streamdeck-audiometer/packages.config
+++ b/streamdeck-audiometer/packages.config
@@ -1,19 +1,16 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="CommandLineParser" version="2.8.0" targetFramework="net472" />
-  <package id="Microsoft.Win32.Registry" version="5.0.0" targetFramework="net472" />
-  <package id="NAudio" version="2.0.0" targetFramework="net472" />
-  <package id="NAudio.Asio" version="2.0.0" targetFramework="net472" />
-  <package id="NAudio.Core" version="2.0.0" targetFramework="net472" />
-  <package id="NAudio.Midi" version="2.0.0" targetFramework="net472" />
-  <package id="NAudio.Wasapi" version="2.0.0" targetFramework="net472" />
-  <package id="NAudio.WinForms" version="2.0.0" targetFramework="net472" />
-  <package id="NAudio.WinMM" version="2.0.0" targetFramework="net472" />
+  <package id="CommandLineParser" version="2.9.1" targetFramework="net472" />
+  <package id="NAudio" version="2.1.0" targetFramework="net472" />
+  <package id="NAudio.Asio" version="2.1.0" targetFramework="net472" />
+  <package id="NAudio.Core" version="2.1.0" targetFramework="net472" />
+  <package id="NAudio.Midi" version="2.1.0" targetFramework="net472" />
+  <package id="NAudio.Wasapi" version="2.1.0" targetFramework="net472" />
+  <package id="NAudio.WinForms" version="2.1.0" targetFramework="net472" />
+  <package id="NAudio.WinMM" version="2.1.0" targetFramework="net472" />
   <package id="Newtonsoft.Json" version="13.0.1" targetFramework="net472" />
-  <package id="NLog" version="4.7.10" targetFramework="net472" />
+  <package id="NLog" version="5.0.1" targetFramework="net472" />
   <package id="streamdeck-client-csharp" version="4.3.0" targetFramework="net472" />
   <package id="StreamDeck-Tools" version="3.2.0" targetFramework="net472" />
-  <package id="System.Drawing.Common" version="5.0.2" targetFramework="net472" />
-  <package id="System.Security.AccessControl" version="5.0.0" targetFramework="net472" />
-  <package id="System.Security.Principal.Windows" version="5.0.0" targetFramework="net472" />
+  <package id="System.Drawing.Common" version="6.0.0" targetFramework="net472" />
 </packages>


### PR DESCRIPTION
Steps to reproduce:
- Have many (10-15+) audio devices to enumerate
- Place a vu meter for a device onto 2 different stream deck pages
- Watch the task manager in Windows for the audiometer sub-process and cpu usage when starting stream deck software up
- Watch the task manager again when switching pages in the stream deck (causes tear down / dispose and re-initialization of button)

Expected results:
- Enumeration to complete quickly and VU meter to display valid numbers

Actual results:
- Enumeration takes upwards of 20s to complete and a cpu core is maxed the whole time, display produces nothing until this completes

Root cause:
- Although the event for the display update is an async method, it's called directly and on a 200ms repeat timer in separate threads by the caller; the wrapper sdk
- This means if it takes 2s to enumerate devices once, by the time 2s has passed, there's already 10 other threads all trying to enumerate the same data in other threads concurrently
- As this all takes place on a single core, it just locks it up until all the threads finish enumerating, around 20s give or take

Solution:
- Since we don't have direct control over the caller to stop it invoking multiple times, we can slow things down ourselves
- This also makes the async approach moot because there's no awaiting/callback for the results anyway, it's synchronously called, plus it wouldn't stop a separate async call in each thread from all enumerating on a line
- So instead we take over the interval of the timer on the first call to us (when current device is null and enumeration is about to start) and ramp it up to 30s
- Enumeration then takes place as normal, but only takes 2s
- During this time, the timer doesn't spin up any additional threads
- Once enumeration completes, we ramp down the timer interval to 200ms or its prior value to us, whichever was lower (it is currently defaulting to 200ms anyway)
- Subsequent calls then operate every ~200ms as normal and skip further enumeration and just grab the value they want to display